### PR TITLE
Fixed max_age setting failing to filter old items

### DIFF
--- a/feed2discord.py
+++ b/feed2discord.py
@@ -428,7 +428,9 @@ def background_check_feed(feed,asyncioloop):
                     # max_age is mostly so that first run doesn't spew too much stuff into a room,
                     # but is also a useful safety measure in case a feed suddenly reverts to something ancient
                     # or other weird problems...
-                    if abs(pubDate_parsed.astimezone(timezone) - timezone.localize(datetime.now())).seconds < max_age:
+                    time_since_published = timezone.localize(datetime.now()) - pubDate_parsed.astimezone(timezone)
+                    
+                    if time_since_published.total_seconds() < max_age:
                         logger.info(feed+':item:fresh and ready for parsing')
                       
                         # Loop over all channels for this particular feed and process appropriately:


### PR DESCRIPTION
This change fixes #28 so `max_age` actually filters older articles by using [`.total_seconds()`](https://docs.python.org/3/library/datetime.html#datetime.timedelta) instead of `.seconds`.

`timedelta` stores the difference between two `datetime` objects as the number of `.days` plus the remaining `.seconds` and `.microseconds`.  This means `.seconds` is always less than 24 hours worth of seconds (86400).  Consequently, `.seconds < max_age` makes no sense when `now - publish_date` is longer than one day because the days aren't counted, resulting in false positives with older articles.

`.total_seconds()` adds up `.days`, `.seconds`, and `.microseconds` as seconds, so `.total_seconds() < max_age` results in the desired behavior and older articles are ignored.